### PR TITLE
analisi compile with AppleClang 12.0.5.12050022

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,10 @@ endif()
 endif()
 
 add_library(${PROJECT_NAME}_lib STATIC ${ANALISI_LIB})
-#target_link_libraries(${PROJECT_NAME}_lib rt)
+if (NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang")  )
+  #with Clang not use rt
+   target_link_libraries(${PROJECT_NAME}_lib rt)
+endif()
 target_include_directories(${PROJECT_NAME}_lib PUBLIC lib/include )
 set_property(TARGET ${PROJECT_NAME}_lib PROPERTY POSITION_INDEPENDENT_CODE ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ endif()
 endif()
 
 add_library(${PROJECT_NAME}_lib STATIC ${ANALISI_LIB})
-target_link_libraries(${PROJECT_NAME}_lib rt)
+#target_link_libraries(${PROJECT_NAME}_lib rt)
 target_include_directories(${PROJECT_NAME}_lib PUBLIC lib/include )
 set_property(TARGET ${PROJECT_NAME}_lib PROPERTY POSITION_INDEPENDENT_CODE ON)
 

--- a/lib/include/calcolamultithread.h
+++ b/lib/include/calcolamultithread.h
@@ -63,11 +63,11 @@ public:
         }
         t0=0;t1=1;
         i0=0;i1=1;
-        if constexpr (FLAGS & CalcolaMultiThread_Flags::PARALLEL_LOOP_AVERAGE) {
+        if constexpr ( !!(FLAGS & CalcolaMultiThread_Flags::PARALLEL_LOOP_AVERAGE)) {
             i0=0;
             i1=ntimesteps;
         }
-        if constexpr (FLAGS & CalcolaMultiThread_Flags::PARALLEL_LOOP_TIME) {
+        if constexpr ( !!(FLAGS & CalcolaMultiThread_Flags::PARALLEL_LOOP_TIME)) {
             t0=0;
             t1=leff;
         }
@@ -75,7 +75,7 @@ public:
 
     void calcola(unsigned int primo){
         init_split();
-        if constexpr (FLAGS & CalcolaMultiThread_Flags::CALL_CALC_INIT) {
+        if constexpr (!!(FLAGS & CalcolaMultiThread_Flags::CALL_CALC_INIT)) {
             static_cast<T*>(this)->calc_init(primo);
         }
         std::vector<std::thread> threads;
@@ -102,12 +102,12 @@ public:
                     t.join();
                 }
                 threads.clear();
-                if constexpr (FLAGS & CalcolaMultiThread_Flags::CALL_INNER_JOIN_DATA)
+                if constexpr (!!(FLAGS & CalcolaMultiThread_Flags::CALL_INNER_JOIN_DATA))
                     static_cast<T*>(this)->join_data();
             }
         }
 
-        if constexpr (FLAGS & CalcolaMultiThread_Flags::CALL_DEBUG_ROUTINE) {
+        if constexpr (!!(FLAGS & CalcolaMultiThread_Flags::CALL_DEBUG_ROUTINE)) {
             static_cast<T*>(this)->calc_end();
         }
 

--- a/lib/include/centerdiff.h
+++ b/lib/include/centerdiff.h
@@ -3,6 +3,7 @@
 
 #include "calcolamultithread.h"
 #include "operazionisulista.h"
+#include <array>
 
 class CenterDiff : public CalcolaMultiThread<CenterDiff>, public OperazioniSuLista<CenterDiff,double>
 {

--- a/lib/src/atomicdensity.cpp
+++ b/lib/src/atomicdensity.cpp
@@ -63,7 +63,7 @@ std::vector<ssize_t>  AtomicDensity<T,Hist>::get_shape() const{
 }
 template <class T, class Hist>
 std::vector<ssize_t>  AtomicDensity<T,Hist>::get_stride() const {
-    return {sizeof (Hist)*static_cast<long>(nbin[0]*nbin[1]*nbin[2]),static_cast<long>(nbin[1]*nbin[2]*sizeof (Hist)),static_cast<long>(nbin[2]*sizeof (Hist)),static_cast<long>(sizeof (Hist))};
+    return {static_cast<long>(sizeof (Hist))*static_cast<long>(nbin[0]*nbin[1]*nbin[2]),static_cast<long>(nbin[1]*nbin[2]*sizeof (Hist)),static_cast<long>(nbin[2]*sizeof (Hist)),static_cast<long>(sizeof (Hist))};
 }
 
 #include "traiettoria.h"

--- a/lib/src/correlatorespaziale.cpp
+++ b/lib/src/correlatorespaziale.cpp
@@ -12,6 +12,7 @@
 
 #include <cmath>
 #include<thread>
+#include <array>
 
 #include "correlatorespaziale.h"
 #include "traiettoria.h"


### PR DESCRIPTION
the code now compiles and works (I hope It passes all the tests at least) with the clang compiler on mac.
version AppleClang 12.0.5.12050022

added few `#include <array>`
without that I got errors like
`analisi_git/lib/src/correlatorespaziale.cpp:100:31: error: type 'std::__1::array<double, 3>' does not provide a subscript operator
            double kmod=sqrt(k[0]*k[0]+k[1]*k[1]+k[2]*k[2]);`


Added some `static_cast<float>` to solve errors like:
```
analisi_git/lib/src/atomicdensity.cpp:66:13: error: non-constant-expression cannot be narrowed from type 'unsigned long' to 'long' in initializer list [-Wc++11-narrowing]
    return {sizeof (Hist)*static_cast<long>(nbin[0]*nbin[1]*nbin[2]),static_cast<long>(nbin[1]*nbin[2]*sizeof (Hist)),static_cast<long>(nbin[2]*sizeof (Hist)),static_cast<long>(sizeof (Hist))};
```

I just followed the compiler suggestion printed after this error.

The more tricky part is the if clause with `constexpr `, it seems a difference between gcc and clang:
see the conversation in [https://bugs.llvm.org/show_bug.cgi?id=39322](https://bugs.llvm.org/show_bug.cgi?id=39322), solved with the suggestion in [https://stackoverflow.com/questions/54899466/constexpr-if-with-a-non-bool-condition](https://stackoverflow.com/questions/54899466/constexpr-if-with-a-non-bool-condition).

Then the `-lrt` during linking seems not to be needed with clang (and it do not work if added) see [https://stackoverflow.com/questions/49656430/what-is-the-c-library-rt?noredirect=1&lq=1](https://stackoverflow.com/questions/49656430/what-is-the-c-library-rt?noredirect=1&lq=1)

